### PR TITLE
Clarify immutability of configuration

### DIFF
--- a/content/documentation/configuration.md
+++ b/content/documentation/configuration.md
@@ -36,7 +36,7 @@ Example of overriding the severity level:
 java -jar -Dtinylog.writer.level=debug application.jar
 ```
 
-tinylog can also be configured programmatically by using the class `Configuration`. Unlike system properties, `Configuration` does expect all properties without "tinylog." prefix (same as in `tinylog.properties`). Individual properties can be set or overridden via `set(String key, String value)`. A complete configuration can also be passed as a map via `replace(Map<String, String> configuration)`. All properties that have already been set are overwritten. The configuration of tinylog will become immutable as soon as the first log entry is issued. Further configuration changes will be silently ignored in tinylog 2.0 and 2.1. Since version 2.2, an `UnsupportedOperationException` will be thrown instead.
+tinylog can also be configured programmatically by using the class `Configuration`. Unlike system properties, `Configuration` does expect all properties without "tinylog." prefix (same as in `tinylog.properties`). Individual properties can be set or overridden via `set(String key, String value)`. A complete configuration can also be passed as a map via `replace(Map<String, String> configuration)`. All properties that have already been set are overwritten. The tinylog configuration becomes immutable once it is accessed for the first time, such as when a log entry is written, a logger is created, or the configuration is retrieved using `get(String key)`. Further configuration changes will be silently ignored in tinylog 2.0 and 2.1. Since version 2.2, an `UnsupportedOperationException` will be thrown instead.
 
 ## Automatic Shutdown
 


### PR DESCRIPTION
Hi, I want to propose a small change concerning the configuration immutability.
When I first read the existing paragraph, I did expect to be able to change the configuration up until the first call to `Logger.info/warn/etc`. 

What I did not consider was that I am using SLF4j. So I noticed that the creation of a logger as static field in the class containing the `main` method is sufficient to freeze the configuration immediately upon application startup. I was surprised a second time when I noticed that even a call to `Configuration.get(String key)` leads to a freeze (see: https://github.com/tinylog-org/tinylog/blob/f25218440fdace8fbe2bcc6bbb9383fe7e475bb7/tinylog-api/src/main/java/org/tinylog/configuration/Configuration.java#L194).

To minimize confusion for other users, I would like to clarify this aspect in the documentation. I am open to hearing other suggestions on how to rephrase this!